### PR TITLE
Bugfix/refactor regex free link builder 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.html]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,14 @@
+{
+    "evil": true,
+    "eqeqeq": true,
+    "freeze": true,
+    "immed": true,
+    "latedef": true,
+    "node": true,
+    "noempty": true,
+    "quotmark": "single",
+    "sub": true,
+    "trailing": true,
+    "undef": true,
+    "unused": true
+}

--- a/README.md
+++ b/README.md
@@ -4,20 +4,43 @@ Parses a JSON config file into valid Express route handlers and URI path builder
 
 Each row, each "route", includes standard Express-ready path which may contain Regular Expressions, and one or more HTTP protocol handlers, to be executed should the path match.
 
-### Intallation
+## Installation
 
 ```sh
 npm install route-registry --save
 ```
 
-### Example
+## Examples
 
-```json
-{
+Initialize your register by adding routes (typically this would be an external JSON config file, but here we'll just use a JS variable):
+
+```js
+var routeRegistry = require('route-registry');
+
+var RoutesConfig = {
     "homepage": { "path": "/", "get": "home.index", "post": "homeIndex" },
     "blogger": { "path": "/authors/:name-:id(\\d+)", "get": "bloggerBio" },
     "photoGallery": { "path": "/photos/:name-:id(\\d+)", "get": "photoGallery" },
     "photoGalleryPhoto": { "path": "/photos/:name-:id(\\d+)/photo/:photoNumber(\\d+)", "get": "photoGalleryPhoto" },
 }
+
+for (var routeName in RoutesConfig) {
+  if (RoutesConfig.hasOwnProperty(routeName)) {
+    routeRegistry.register(RoutesConfig[routeName].path, routeName);
+  }
+}
 ```
 
+### Use As Link Builder
+
+After initializing your registry you may use it within any file to generate links by calling the route as a method and passing a params object with values for each `:key`:
+
+```js
+var routeRegistry = require('route-registry');
+var uri = routeRegistry.link.blogger({
+        name: 'peter-parker',
+        id: 20445
+    });
+
+console.log(uri);
+```

--- a/lib/routeRegistry.js
+++ b/lib/routeRegistry.js
@@ -1,112 +1,128 @@
-var pathToRegexp = require('path-to-regexp'),
-	methods = ['all', 'get', 'post', 'put', 'delete'],
-	space = /\s/g,
-	unsafeCharacters = /[^a-z0-9\s]/gi,
-	errors = {
-		DUPLICATE_ROUTE: 'Route with name "%s" exists'
-	},
-	link = {},
-	registry = {},
-	routes = [],
-	defaultMiddleware = [];
+var pathToRegexp = require('path-to-regexp');
+var methods = ['all', 'get', 'post', 'put', 'delete'];
+var space = /\s/g;
+var unsafeCharacters = /[^a-z0-9\s]/gi;
+var errors = {
+  DUPLICATE_ROUTE: 'Route with name "%s" exists'
+};
+var link = {};
+var registry = {};
+var routes = [];
+var defaultMiddleware = [];
 
 function use(fn) {
-	defaultMiddleware.push(fn);
+  defaultMiddleware.push(fn);
 }
 
 function keyToRegExp(key) {
-	return new RegExp(':(' + key + ')(?:\\(([^\\(]+)\\))?');
+  return new RegExp(':(' + key + ')(?:\\(([^\\(]+)\\))?');
 }
 
 function getLink(name, params) {
-	var	route = registry[name],
-			path = route && route.path,
-			keys = route.keys.map(function (key) {
-				return key.name;
-			});
+  var route = registry[name];
+  var path = route && route.path;
+  route.keys.map(function (key) {
+    return key.name;
+  });
 
-	if (!path) return;
+  if (!path) return;
 
-	if (params) {
-		route.keys.forEach(function (key) {
-			var opts = params[key.name],
-					value;
+  if (params) {
+    route.keys.forEach(function (key) {
+      var opts = params[key.name];
+      var value;
 
-			if ('undefined' === typeof opts) return;
+      if ('undefined' === typeof opts) return;
 
-			value = ('object' === typeof opts ? opts.value : opts).toString();
+      value = ('object' === typeof opts ? opts.value : opts).toString();
 
-			if (opts.lowercase) value = value.toLowerCase();
-			if (opts.encode) value = encodeURIComponent(value);
-			if (opts.strip) value = value.replace(unsafeCharacters, '');
+      if (opts.lowercase) {
+        value = value.toLowerCase();
+      }
+      if (opts.encode) {
+        value = encodeURIComponent(value);
+      }
+      if (opts.strip) {
+        value = value.replace(unsafeCharacters, '');
+      }
 
-			if ('undefined' === typeof opts.replaceSpaces || 'string' === typeof opts.replaceSpaces) value = value.replace(space, opts.replaceSpaces || '-');
+      if ('undefined' === typeof opts.replaceSpaces || 'string' === typeof opts.replaceSpaces) {
+        value = value.replace(space, opts.replaceSpaces || '-');
+      }
 
-			path = path.replace(keyToRegExp(key.name), value);
-		});
-	}
+      path = path.replace(keyToRegExp(key.name), value);
+    });
+  }
 
-	return path;
+  return path;
 }
 
 function register(path, name) {
-	if (registry[name]) throw new Error(errors.DUPLICATE_ROUTE.replace('%s', name));
+  if (registry[name]) {
+    throw new Error(errors.DUPLICATE_ROUTE.replace('%s', name));
+  }
 
-	var keys = [],
-		exp = pathToRegexp(path, keys);
+  var keys = [];
+  var exp = pathToRegexp(path, keys);
 
-	registry[name] = {
-		path: path,
-		keys: keys,
-		regexp: exp
-	};
+  registry[name] = {
+    path: path,
+    keys: keys,
+    regexp: exp
+  };
 
-	link[name] = function (params) {
-		return getLink(name, params);
-	};
+  link[name] = function (params) {
+    return getLink(name, params);
+  };
 }
 
 function applyRoutes(app) {
-	routes.forEach(function (route) {
-		var method = route.shift(),
-			path = route.shift(),
-			properties = route.length > 1 && 'function' !== typeof route[0] ? route.shift() : null,
-			middleware = [];
+  routes.forEach(function (route) {
+    var method = route.shift();
+    var path = route.shift();
+    var properties = route.length > 1 && 'function' !== typeof route[0] ? route.shift() : null;
+    var middleware = [];
 
-		if (properties) {
-			properties = 'object' === typeof properties ? properties : { name: properties };
-			if (properties.name) register(path, properties.name);
-			middleware.push(function (req, res, next) {
-				res.locals.route = properties;
-				for (var property in properties) {
-					if (!req.route[property]) req.route[property] = properties[property];
-				}
-				next();
-			});
-		}
+    if (properties) {
+      properties = 'object' === typeof properties ? properties : {
+        name: properties
+      };
+      if (properties.name) {
+        register(path, properties.name);
+      }
+      middleware.push(function (req, res, next) {
+        res.locals.route = properties;
+        for (var property in properties) {
+          if (!req.route[property]) {
+            req.route[property] = properties[property];
+          }
+        }
+        next();
+      });
+    }
 
-		middleware = middleware
-			.concat(defaultMiddleware)
-			.concat(route);
+    middleware = middleware
+      .concat(defaultMiddleware)
+      .concat(route);
 
-		app[method].apply(app, [path].concat(middleware));
-	});
+    app[method].apply(app, [path].concat(middleware));
+  });
 }
 
 exports = {
-	applyRoutes: applyRoutes,
-	link: link,
-	methods: methods,
-	register: register,
-	registry: registry,
-	use: use
+  applyRoutes: applyRoutes,
+  link: link,
+  methods: methods,
+  register: register,
+  registry: registry,
+  use: use
 };
 
 methods.forEach(function (method) {
-	exports[method] = function () {
-		var args = [method].concat(Array.prototype.slice.call(arguments));
-		routes.push(args);
-	};
+  exports[method] = function () {
+    var args = [method].concat(Array.prototype.slice.call(arguments));
+    routes.push(args);
+  };
 });
 
 module.exports = exports;

--- a/lib/routeRegistry.js
+++ b/lib/routeRegistry.js
@@ -1,10 +1,15 @@
+/* jshint esnext:true */
 var pathToRegexp = require('path-to-regexp');
-var methods = ['all', 'get', 'post', 'put', 'delete'];
-var space = /\s/g;
-var unsafeCharacters = /[^a-z0-9\s]/gi;
-var errors = {
+
+const METHODS = ['all', 'get', 'post', 'put', 'delete'];
+const RegExes = {
+  SPACE: /\s/g,
+  UNSAFE_CHARS: /[^a-z0-9\s]/gi
+};
+const Errors = {
   DUPLICATE_ROUTE: 'Route with name "%s" exists'
 };
+
 var link = {};
 var registry = {};
 var routes = [];
@@ -25,14 +30,18 @@ function getLink(name, params) {
     return key.name;
   });
 
-  if (!path) return;
+  if (!path) {
+    return;
+  }
 
   if (params) {
     route.keys.forEach(function (key) {
       var opts = params[key.name];
       var value;
 
-      if ('undefined' === typeof opts) return;
+      if ('undefined' === typeof opts) {
+        return;
+      }
 
       value = ('object' === typeof opts ? opts.value : opts).toString();
 
@@ -43,11 +52,11 @@ function getLink(name, params) {
         value = encodeURIComponent(value);
       }
       if (opts.strip) {
-        value = value.replace(unsafeCharacters, '');
+        value = value.replace(RegExes.UNSAFE_CHARS, '');
       }
 
       if ('undefined' === typeof opts.replaceSpaces || 'string' === typeof opts.replaceSpaces) {
-        value = value.replace(space, opts.replaceSpaces || '-');
+        value = value.replace(RegExes.SPACE, opts.replaceSpaces || '-');
       }
 
       path = path.replace(keyToRegExp(key.name), value);
@@ -59,7 +68,7 @@ function getLink(name, params) {
 
 function register(path, name) {
   if (registry[name]) {
-    throw new Error(errors.DUPLICATE_ROUTE.replace('%s', name));
+    throw new Error(Errors.DUPLICATE_ROUTE.replace('%s', name));
   }
 
   var keys = [];
@@ -112,13 +121,13 @@ function applyRoutes(app) {
 exports = {
   applyRoutes: applyRoutes,
   link: link,
-  methods: methods,
+  methods: METHODS,
   register: register,
   registry: registry,
   use: use
 };
 
-methods.forEach(function (method) {
+METHODS.forEach(function (method) {
   exports[method] = function () {
     var args = [method].concat(Array.prototype.slice.call(arguments));
     routes.push(args);

--- a/lib/routeRegistry.js
+++ b/lib/routeRegistry.js
@@ -3,6 +3,7 @@ var pathToRegexp = require('path-to-regexp');
 
 const METHODS = ['all', 'get', 'post', 'put', 'delete'];
 const RegExes = {
+  KEY: /:(\w+)(?:\(([^\(]+)\))?/,
   SPACE: /\s/g,
   UNSAFE_CHARS: /[^a-z0-9\s]/gi
 };
@@ -19,51 +20,86 @@ function use(fn) {
   defaultMiddleware.push(fn);
 }
 
-function keyToRegExp(key) {
-  return new RegExp(':(' + key + ')(?:\\(([^\\(]+)\\))?');
+function toValue(opts, value) {
+  if (!value || !value.toString) {
+    return '';
+  }
+
+  var result = value.toString();
+  if (opts.lowercase) {
+    result = result.toLowerCase();
+  }
+
+  if (opts.encode) {
+    result = encodeURIComponent(result);
+  }
+
+  if (opts.strip) {
+    result = result.replace(RegExes.UNSAFE_CHARS, '');
+  }
+
+  if ('undefined' === typeof opts.replaceSpaces || 'string' === typeof opts.replaceSpaces) {
+    result = result.replace(RegExes.SPACE, opts.replaceSpaces || '-');
+  }
+
+  return result;
 }
 
 function getLink(name, params) {
   var route = registry[name];
-  var path = route && route.path;
-  route.keys.map(function (key) {
-    return key.name;
+
+  if (!route || !route.pathTokens) {
+    return '';
+  }
+
+  if (!params) {
+    return '';
+  }
+
+  var result = '';
+
+  route.pathTokens.forEach(function (data) {
+    if (data.literal) {
+      result += data.literal || '';
+    } else {
+      var opts = params[data.key];
+      if (!opts) {
+        result += ':' + data.key;
+      } else {
+        result += toValue(opts, typeof opts === 'object' ? opts.value : opts) || (':' + data.key);
+      }
+    }
   });
 
-  if (!path) {
-    return;
+  return result;
+}
+
+function tokenizePath(path) {
+  var result = [];
+  var matches = true;
+  var stringLiteral = '';
+
+  while (path.length && matches) {
+    matches = path.match(RegExes.KEY);
+    stringLiteral = matches ? path.substr(0, matches.index) : path;
+
+    if (stringLiteral) {
+      result.push({
+        literal: stringLiteral
+      });
+    }
+
+    if (!matches) {
+      path = '';
+    } else {
+      result.push({
+        key: matches[1]
+      });
+      path = path.substring(matches.index + matches[0].length);
+    }
   }
 
-  if (params) {
-    route.keys.forEach(function (key) {
-      var opts = params[key.name];
-      var value;
-
-      if ('undefined' === typeof opts) {
-        return;
-      }
-
-      value = ('object' === typeof opts ? opts.value : opts).toString();
-
-      if (opts.lowercase) {
-        value = value.toLowerCase();
-      }
-      if (opts.encode) {
-        value = encodeURIComponent(value);
-      }
-      if (opts.strip) {
-        value = value.replace(RegExes.UNSAFE_CHARS, '');
-      }
-
-      if ('undefined' === typeof opts.replaceSpaces || 'string' === typeof opts.replaceSpaces) {
-        value = value.replace(RegExes.SPACE, opts.replaceSpaces || '-');
-      }
-
-      path = path.replace(keyToRegExp(key.name), value);
-    });
-  }
-
-  return path;
+  return result;
 }
 
 function register(path, name) {
@@ -77,7 +113,8 @@ function register(path, name) {
   registry[name] = {
     path: path,
     keys: keys,
-    regexp: exp
+    regexp: exp,
+    pathTokens: tokenizePath(path)
   };
 
   link[name] = function (params) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-registry",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Express route registry.",
   "main": "index.js",
   "scripts": {

--- a/test/link.js
+++ b/test/link.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 const RoutesConfig = {
   blogPost: {
-    path: 'http://www.mydomainname.com/:title:id/article',
+    path: 'http://www.mydomainname.com/:title-:id/article',
     get: 'noop'
   },
   relativeBlogPost: {
@@ -30,7 +30,7 @@ const LinkTests = [{
     title: 'pickles-mcgee',
     id: 90003
   },
-  expected: 'http://www.mydomainname.com/pickles-mcgee90003/article',
+  expected: 'http://www.mydomainname.com/pickles-mcgee-90003/article',
   description: 'Basic, safe'
 }, {
   routeName: 'blogPost',
@@ -38,7 +38,7 @@ const LinkTests = [{
     title_: 'superman-is-lame_',
     id: 90004
   },
-  expected: 'http://www.mydomainname.com/:title90004/article',
+  expected: 'http://www.mydomainname.com/:title-90004/article',
   description: 'param with underscore suffix'
 }, {
   routeName: 'relativeBlogPost',
@@ -79,6 +79,14 @@ const LinkTests = [{
   },
   expected: '/pizza/neat',
   description: 'No Keys in path definition'
+}, {
+  routeName: 'blogPost',
+  params: {
+    title: 'superman:identity-challenged:idealogue-man:idefinite',
+    id: 40044
+  },
+  expected: 'http://www.mydomainname.com/superman:identity-challenged:idealogue-man:idefinite-40044/article',
+  description: 'Multiple possible ":id" param matches within title'
 }];
 
 for (var routeName in RoutesConfig) {
@@ -89,7 +97,7 @@ for (var routeName in RoutesConfig) {
 
 describe('Correct Links', function () {
   LinkTests.forEach(function (value) {
-    it('(' + value.description + ') Route: ' + value.routeName, function () {
+    it(value.description + ' (route: ' + value.routeName + ')', function () {
       assert.equal(routeRegistry.link[value.routeName](value.params), value.expected);
     });
   });

--- a/test/link.js
+++ b/test/link.js
@@ -21,8 +21,13 @@ const RoutesConfig = {
   },
   noKeys: {
     path: '/pizza/neat'
+  },
+  invalidKays: {
+    path: '/:/:'
   }
 };
+
+var FORCE_UNDEFINED;
 
 const LinkTests = [{
   routeName: 'blogPost',
@@ -39,7 +44,7 @@ const LinkTests = [{
     id: 90004
   },
   expected: 'http://www.mydomainname.com/:title-90004/article',
-  description: 'param with underscore suffix'
+  description: 'Param with underscore suffix'
 }, {
   routeName: 'relativeBlogPost',
   params: {
@@ -55,19 +60,19 @@ const LinkTests = [{
     id: 500444,
     title: 'do-not-use'
   },
-  expected: '/my-articles/family/overview/another-folder/:page(\\d+)',
-  description: 'Extra params and one missing'
+  expected: '/my-articles/family/overview/another-folder/:page',
+  description: 'Extra and missing params'
 }, {
   routeName: 'videoPlaylistVideoThemed',
   params: {
-    theme: 'superman-is-lame_', // null
-    playlistName: 183002, // FORCE_UNDEFINED
-    playlistId: '', // [],
-    videoTitle: -1, // {},
-    videoId: 0, // new Date()
+    theme: null,
+    playlistName: FORCE_UNDEFINED,
+    playlistId: [],
+    videoTitle: {},
+    videoId: new Date()
   },
-  expected: '/videos/superman-is-lame_/183002-/-1-0',
-  description: 'Video Playlist (Themed), incorrect param data types'
+  expected: '/videos/:theme/:playlistName-:playlistId/:videoTitle-:videoId',
+  description: 'Incorrect param data types'
 }, {
   routeName: 'noKeys',
   params: {
@@ -87,6 +92,13 @@ const LinkTests = [{
   },
   expected: 'http://www.mydomainname.com/superman:identity-challenged:idealogue-man:idefinite-40044/article',
   description: 'Multiple possible ":id" param matches within title'
+}, {
+  routeName: 'invalidKays',
+  params: {
+    ':': 'unexpected'
+  },
+  expected: '/:/:',
+  description: 'Failed cookies'
 }];
 
 for (var routeName in RoutesConfig) {
@@ -95,7 +107,7 @@ for (var routeName in RoutesConfig) {
   }
 }
 
-describe('Correct Links', function () {
+describe('Link Building: ', function () {
   LinkTests.forEach(function (value) {
     it(value.description + ' (route: ' + value.routeName + ')', function () {
       assert.equal(routeRegistry.link[value.routeName](value.params), value.expected);


### PR DESCRIPTION
The problem we found was when a route's path contains keys that could occur in param values. Here's an example:

```js
const RoutesConfig = {
  blogPost: {
    path: 'http://www.mydomainname.com/:title-:id/article',
    get: 'noop'
  }
};

// initialize router & then...

var url = routeRegistry.link.blogPost({
    title: 'superman:identity-challenged:idealogue-man:idefinite',
    id: 40044
  });
```

The expected, desired value for `url` would be:
```
http://www.mydomainname.com/superman:identity-challenged:idealogue-man:idefinite-40044/article
```

The actual value returned is:
```
http://www.mydomainname.com/superman40044entity-challenged:idealogue-man:idefinite-:id/article
```

This is because the link builder begins with the path and then uses regExes to successively replace possible keys with param values. Since the `title` value contains false-positives for the `id` -- "**:id**entity-challenged", "**:id**ealogue-man", "**:id**efinite" -- we miss the actual `:id` key.

Instead of using regexes this PR tokenizes the path, reducing it into string literals (in our example "http://www.mydomainname.com/", "-", "/article") and keys ("title" and "id"). These are stored in order they are needed so they're easily glued together to form the final URL:

1. literal: "http://www.mydomainname.com/"
2. key: parameter named "title"
3. literal: "-"
4. key: parameter named "id"
5. literal "/article"

It's lite and fairly easy to walk-thru.

Thanks, Mr. Slalom, for looking into this. We much can pleasing if you're fixed on it.